### PR TITLE
Only build DLLs that have a KSPAssemblyDependency on KSPBurst

### DIFF
--- a/GameData/000_KSPBurst/DependencyCompat.cfg
+++ b/GameData/000_KSPBurst/DependencyCompat.cfg
@@ -1,0 +1,40 @@
+// Several KSP mods that use KSPBurst don't have a KSPAssemblyDependency on it.
+// Before 1.7.4.2 this would work because KSPBurst automatically included every
+// DLL in GameData. Unfortunately, there are some mods dlls that break KSPBurst,
+// so now KSPBurst only automatically compiles assemblies that depend on it.
+//
+// You can manually specify that an assembly should be included for KSPBurst
+// compilation by creating a config node like this:
+//
+// KSPBURST_ASSEMBLY
+// {
+//     name = <your assembly name or path>
+// }
+//
+// This config acts as a bridge for all the mods that use burst but that don't
+// declare the appropriate dependency.
+
+KSPBURST_ASSEMBLY
+{
+    name = Kopernicus
+}
+
+KSPBURST_ASSEMBLY
+{
+    name = KSPTextureLoader
+}
+
+KSPBURST_ASSEMBLY
+{
+    name = RealAntennas
+}
+
+// FARc has a broken dependency on Scale_Redist. This seems to work ok for KSP but
+// breaks KSPBurst.
+//
+// See https://github.com/dkavolis/Ferram-Aerospace-Research/issues/160
+//
+// KSPBURST_ASSEMBLY
+// {
+//     name = FerramAerospaceResearch
+// }

--- a/KSPBurst/AssemblyUtil.cs
+++ b/KSPBurst/AssemblyUtil.cs
@@ -25,11 +25,89 @@ namespace KSPBurst
                 .Where(assembly => assembly.path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)).ToArray();
         }
 
-        [NotNull]
-        public static AssemblyVersion[] LoadedPluginVersions()
+        public static bool HasKSPBurstDependency([NotNull] AssemblyLoader.LoadedAssembly loaded)
         {
+            if (loaded is null) throw new ArgumentNullException(nameof(loaded));
+            return loaded.assembly.GetCustomAttributes(typeof(KSPAssemblyDependency), false)
+                .Cast<KSPAssemblyDependency>()
+                .Any(dep => string.Equals(dep.name, PathUtil.ModName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [NotNull]
+        public static AssemblyLoader.LoadedAssembly[] LoadedBurstPlugins()
+        {
+            return LoadedPlugins().Where(HasKSPBurstDependency).ToArray();
+        }
+
+        [NotNull]
+        public static AssemblyLoader.LoadedAssembly[] ApplyAssemblyOverrides(
+            [NotNull] AssemblyLoader.LoadedAssembly[] burstPlugins,
+            [CanBeNull] ConfigNode[] overrideNodes
+        )
+        {
+            if (burstPlugins is null) throw new ArgumentNullException(nameof(burstPlugins));
+            if (overrideNodes is null || overrideNodes.Length == 0)
+                return burstPlugins;
+
+            AssemblyLoader.LoadedAssembly[] allPlugins = LoadedPlugins();
+            List<AssemblyLoader.LoadedAssembly> result = new(burstPlugins);
+
+            foreach (ConfigNode node in overrideNodes)
+            {
+                string name = null;
+                if (!node.TryGetValue("name", ref name))
+                    continue;
+
+                bool enabled = default;
+                if (!node.TryGetValue("enabled", ref enabled))
+                    enabled = true;
+
+                if (enabled)
+                {
+                    foreach (AssemblyLoader.LoadedAssembly plugin in allPlugins)
+                        if (MatchesAssembly(plugin, name) && !result.Contains(plugin))
+                            result.Add(plugin);
+                }
+                else
+                {
+                    result.RemoveAll(plugin => MatchesAssembly(plugin, name));
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        private static bool MatchesAssembly([NotNull] AssemblyLoader.LoadedAssembly plugin, [NotNull] string name)
+        {
+            return string.Equals(plugin.name, name, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(plugin.dllName, name, StringComparison.OrdinalIgnoreCase) ||
+                   plugin.path.EndsWith(name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [NotNull]
+        public static string[] BurstPluginAssemblyPaths([NotNull] AssemblyLoader.LoadedAssembly[] plugins,
+            [CanBeNull] string rootDir = null)
+        {
+            if (plugins is null) throw new ArgumentNullException(nameof(plugins));
+            string[] paths = plugins.Select(assembly => assembly.path).ToArray();
+
+            if (string.IsNullOrEmpty(rootDir)) return paths;
+
+            rootDir = Path.GetFullPath(rootDir);
+            for (var i = 0; i < paths.Length; ++i)
+                paths[i] = PathUtil.GetRelativePath(paths[i], rootDir);
+
+            return paths;
+        }
+
+        [NotNull]
+        public static AssemblyVersion[] LoadedPluginVersions(
+            [NotNull] AssemblyLoader.LoadedAssembly[] plugins)
+        {
+            if (plugins is null) throw new ArgumentNullException(nameof(plugins));
             // merge url into name so that multiple DLLs with the same name but different paths can be distinguished
-            return LoadedPlugins().Select(assembly => new AssemblyVersion
+            // only track plugins that depend on KSPBurst since those are the only ones compiled
+            return plugins.Select(assembly => new AssemblyVersion
             {
                 // use dllName instead of name since it's not guaranteed to be unique as it's set from KSPAssembly attribute
                 Url = $"{assembly.url}/{assembly.dllName}", Guid = assembly.assembly.VersionId(),

--- a/KSPBurst/BurstOptions.cs
+++ b/KSPBurst/BurstOptions.cs
@@ -15,9 +15,14 @@ namespace KSPBurst
             PathUtil.SelectByPlatform(Platform.Windows, Platform.Linux, Platform.macOS);
 
         [NotNull]
-        public static List<string> LoadArgs([NotNull] ConfigNode node, [CanBeNull] string rootDir)
+        public static List<string> LoadArgs(
+            [NotNull] ConfigNode node,
+            [NotNull] AssemblyLoader.LoadedAssembly[] burstPlugins,
+            [CanBeNull] string rootDir
+        )
         {
             if (node is null) throw new ArgumentNullException(nameof(node));
+            if (burstPlugins is null) throw new ArgumentNullException(nameof(burstPlugins));
             if (string.IsNullOrEmpty(rootDir)) rootDir = Directory.GetCurrentDirectory();
 
             List<string> args = new()
@@ -33,29 +38,42 @@ namespace KSPBurst
                 args.AddRange(node.GetValuesList(option.Name).Select(value => option.MakeOption(value))
                     .Where(o => !string.IsNullOrEmpty(o)));
 
-            AddRootAssemblies(args, AssemblyUtil.KspAndPluginAssemblyPaths(false, rootDir));
+            // only compile assemblies that declare a dependency on KSPBurst (with config overrides applied)
+            AddRootAssemblies(args, AssemblyUtil.BurstPluginAssemblyPaths(burstPlugins, rootDir));
+            // but provide all plugin directories so references can be resolved
+            AddAssemblyFolders(args, AssemblyUtil.KspAndPluginAssemblyPaths(false, rootDir));
             string kspPluginDir = Path.Combine(PathUtil.DataDir, "Managed");
             args.Add($"--assembly-folder={PathUtil.GetRelativePath(kspPluginDir, rootDir)}");
 
             return args;
         }
 
-        public static void AddRootAssemblies([NotNull] ICollection<string> args,
-            [NotNull] IEnumerable<string> assemblyPaths)
+        public static void AddRootAssemblies(
+            [NotNull] ICollection<string> args,
+            [NotNull] IEnumerable<string> assemblyPaths
+        )
         {
             if (args is null) throw new ArgumentNullException(nameof(args));
             if (assemblyPaths is null) throw new ArgumentNullException(nameof(assemblyPaths));
 
-            // use hashset to store directories of all libraries
+            foreach (string path in assemblyPaths)
+                args.Add($"--root-assembly={path}");
+        }
+
+        public static void AddAssemblyFolders(
+            [NotNull] ICollection<string> args,
+            [NotNull] IEnumerable<string> assemblyPaths
+        )
+        {
+            if (args is null) throw new ArgumentNullException(nameof(args));
+            if (assemblyPaths is null) throw new ArgumentNullException(nameof(assemblyPaths));
+
             HashSet<string> assemblyFolders = new();
             foreach (string path in assemblyPaths)
-            {
-                string parent = Path.GetDirectoryName(path);
-                args.Add($"--root-assembly={path}");
-                assemblyFolders.Add(parent);
-            }
+                assemblyFolders.Add(Path.GetDirectoryName(path));
 
-            foreach (string assemblyFolder in assemblyFolders) args.Add($"--assembly-folder={assemblyFolder}");
+            foreach (string assemblyFolder in assemblyFolders)
+                args.Add($"--assembly-folder={assemblyFolder}");
         }
 
         public class FlagOption : IOption

--- a/KSPBurst/KSPBurst.cs
+++ b/KSPBurst/KSPBurst.cs
@@ -177,13 +177,17 @@ namespace KSPBurst
                 return result;
             }
 
+            // load config and resolve which assemblies to compile
+            ConfigNode node = GameDatabase.Instance.GetConfigNode($"{PathUtil.ModFolderName}/{PathUtil.ModName}/{PathUtil.ModName}");
+            AssemblyLoader.LoadedAssembly[] burstPlugins = AssemblyUtil.LoadedBurstPlugins();
+            burstPlugins = AssemblyUtil.ApplyAssemblyOverrides(burstPlugins, GameDatabase.Instance.GetConfigNodes("KSPBURST_ASSEMBLY"));
+
             // check if any plugins have changed since last time
-            AssemblyUtil.AssemblyVersionChange[] changes = CollectPluginChanges(packageDir);
+            AssemblyUtil.AssemblyVersionChange[] changes = CollectPluginChanges(packageDir, burstPlugins);
 
             // load burst command line args
-            ConfigNode node = GameDatabase.Instance.GetConfigNode($"{PathUtil.ModFolderName}/{PathUtil.ModName}");
             string cwd = Directory.GetCurrentDirectory();
-            List<string> args = BurstOptions.LoadArgs(node, cwd);
+            List<string> args = BurstOptions.LoadArgs(node, burstPlugins, cwd);
 
             // output command line arguments to log files
             string logDir = PathUtil.ModLogsDir;
@@ -223,15 +227,29 @@ namespace KSPBurst
 
         // ReSharper disable once ReturnTypeCanBeEnumerable.Local
         [NotNull]
-        private static AssemblyUtil.AssemblyVersionChange[] CollectPluginChanges([NotNull] string cacheDir)
+        private static AssemblyUtil.AssemblyVersionChange[] CollectPluginChanges([NotNull] string cacheDir,
+            [NotNull] AssemblyLoader.LoadedAssembly[] burstPlugins)
         {
             if (string.IsNullOrWhiteSpace(cacheDir))
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(cacheDir));
+            if (burstPlugins is null) throw new ArgumentNullException(nameof(burstPlugins));
 
-            AssemblyUtil.AssemblyVersion[] loadedVersions = AssemblyUtil.LoadedPluginVersions();
+            AssemblyUtil.AssemblyVersion[] loadedVersions = AssemblyUtil.LoadedPluginVersions(burstPlugins);
             AssemblyUtil.AssemblyVersion[] cachedVersions = AssemblyUtil.LoadPluginVersionsFromCache(cacheDir);
             AssemblyUtil.AssemblyVersionChange[] changes = AssemblyUtil.ComputeChanges(loadedVersions, cachedVersions);
-            LogFormat("Plugins found:\n{0}", AssemblyUtil.Format(changes));
+            LogFormat(
+                """
+                
+                KSPBurst requires that DLLs wanting to be burst-compiled must have either a KSPAssemblyDependency
+                on KSPBurst or manually opt-in to being compiled by declaring a KSPBURST_ASSEMBLY config.
+                If you aren't seeing your DLL below this is likely the reason why.
+                See https://github.com/KSPModdingLibs/KSPBurst for more information.
+
+                Plugins found:
+                {0}
+                """,
+                AssemblyUtil.Format(changes)
+            );
 
             return changes;
         }

--- a/KSPBurst/KSPBurst.csproj
+++ b/KSPBurst/KSPBurst.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>KSPBurst</AssemblyName>
         <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
-        <LangVersion>9</LangVersion>
+        <LangVersion>11</LangVersion>
         <StartProgram>$(KSP_DIR)\KSP_x64.exe</StartProgram>
         <StartWorkingDirectory>$(KSP_DIR)</StartWorkingDirectory>
     </PropertyGroup>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,6 +45,20 @@ Burst compatible Unity plugins and their dependencies are also bundled:
 
 [comment]: # (end_packages)
 
+As of 1.7.4.2 KSPBurst will only automatically compile DLLs that have a `KSPAssemblyDependency` on KSPBurst.
+Make sure to add a `KSPAssemblyDependency` attribute on KSPBurst to your DLL or else your jobs or methods
+will not be burst-compiled.
+
+If you cannot take a direct dependency on KSPBurst for whatever reason, you can manually indicate that
+KSPBurst should compile your DLL by creating a `KSPBURST_ASSEMBLY` config node like so:
+
+```
+KSPBURST_ASSEMBLY
+{
+  name = <your DLL's KSPAssemblyName>
+}
+```
+
 ## Configuration Options
 
 All configuration options present in `KSPBurst.cfg` map directly to `bcl.exe` command line options. If `ModuleManager`


### PR DESCRIPTION
This commit makes so by default only dlls that have a KSPAssemblyDependency on KSPBurst are fed into the burst compiler. Some don't (and sometimes we want to exclude dlls) so it also allows you to specify

```
KSPBURST_ASSEMBLY
{
   name = <assembly name or path>
}
```
to explicitly include DLLs that don't have a dependency.

To disable a dll you can do
```
KSPBURST_ASSEMBLY
{
   name = ...
   enabled = false
}
```
There are a few existing mods that expect to be burst-compiled but that do not have a KSPAssemblyDependency on KSPBurst. I have included compatiblity entries for them so that they still get loaded. In the future I expect to upstream the entries directly into those mods.

---
The motivation for this change is mostly https://github.com/dkavolis/Ferram-Aerospace-Research/issues/160, where FAR has a broken dependency and that breaks KSPBurst. I have also seen several warnings from other mods. I'm not entirely sure if these kill KSPBurst as well, but I figure it is much safer to make burst-compilation opt-in. Keying it off `KSPAssemblyDependency` means that most downstream mods should just get it right without having to think about it. To help people figure it out I have also added a message to the log that explains this and points to the readme.