### PR TITLE
Clean up old log files before compiling

### DIFF
--- a/KSPBurst/KSPBurst.cs
+++ b/KSPBurst/KSPBurst.cs
@@ -222,6 +222,10 @@ namespace KSPBurst
             // save command line arguments for later inspection/next run
             File.WriteAllText(cliFile, argStr);
 
+            // clean up log files from any previous compilation before starting a new one
+            File.Delete($"{logDir}/KSPBurst-stdout.log");
+            File.Delete($"{logDir}/KSPBurst-stderr.log");
+
             LogFormat("Burst called with arguments in {0}:\n{1}", cwd, argStr);
             result = RunBurstCompiler(burstExecutable, args, cwd, logDir);
 


### PR DESCRIPTION
It is incredibly confusing when an old KSPBurst-stderr.log file sticks around. Deleting them first solves this issue.