### PR TITLE
Disable BC1370 by default

### DIFF
--- a/GameData/000_KSPBurst/KSPBurst.cfg
+++ b/GameData/000_KSPBurst/KSPBurst.cfg
@@ -21,7 +21,7 @@ KSPBurst
     generate-static-linkage-methods = false
     generate-job-marshalling-methods = false
     // temp-folder =
-    // disable-warnings = BC1370
+    disable-warnings = BC1370
     // linker-options =
     enable-direct-external-linking = false
     use-platform-sdk-linkers = false


### PR DESCRIPTION
This warning looks scary to users but is ultimately pretty much harmless. Disabling it by default avoids a lot of logspam.